### PR TITLE
fix: typos in error.rs

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -10,9 +10,9 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Error::LSTSQError(msg) => write!(f, "LSTQS failed: {msg}"),
+            Error::LSTSQError(msg) => write!(f, "LSTSQ failed: {msg}"),
             Error::ParseNotationError => write!(f, "Can't convert string to Name"),
-            Error::MissingFunctionCoeffsError => write!(f, "No cofficients to compute f(x)"),
+            Error::MissingFunctionCoeffsError => write!(f, "No coefficients to compute f(x)"),
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix typos in LSTSQ error message
- fix typo in MissingFunctionCoeffsError message

## Testing
- `cargo check` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6874a975716c832d818491af0de87766