### PR TITLE
fix: base value in exponential validation test

### DIFF
--- a/.github/workflows/pr-conventional-commits.yaml
+++ b/.github/workflows/pr-conventional-commits.yaml
@@ -1,0 +1,42 @@
+name: PR Conventional Commits
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # When getting Rust dependencies, retry on network error:
+  CARGO_NET_RETRY: 10
+  # Use the local .curlrc
+  CURL_HOME: .
+
+jobs:
+  check:
+    name: conventional-pr-title:required
+    runs-on: ubuntu-latest
+    env:
+      TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      # Conventional commit patterns:
+      #   verb: description
+      #   verb!: description of breaking change
+      #   verb(scope): Description of change to $scope
+      #   verb(scope)!: Description of breaking change to $scope
+      # verb: feat, fix, ...
+      # scope: refers to the part of code being changed.  E.g. " (accounts)" or " (accounts,canisters)"
+      # !: Indicates that the PR contains a breaking change.
+      - run: |
+          if [[ "$TITLE" =~ ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?: ]]; then
+              echo pass
+          else
+              echo "PR title does not match conventions"
+              exit 1
+          fi
+

--- a/.github/workflows/pre-merge-checks.yaml
+++ b/.github/workflows/pre-merge-checks.yaml
@@ -1,13 +1,15 @@
-name: Rust
+name: Pre-Merge Checks
 
 on:
-  push:
-    branches: [ main, dev ]
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+  workflow_dispatch: # Allows manual trigger for any branch
 
 env:
+  RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
+  TERM: xterm-256color
 
 jobs:
   build:

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -130,7 +130,7 @@ mod tests {
     fn exponential_degraded_to_constant_base_1() {
         // f(x) = gain * 1 ^ x = gain
         assert_eq!(
-            is_degraded(Name::Exponential, &Params::new().base(0.0).build()),
+            is_degraded(Name::Exponential, &Params::new().base(1.0).build()),
             Some(Name::Constant)
         );
     }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -49,7 +49,7 @@ fn is_degraded(name: Name, p: &Params) -> Option<Name> {
 pub fn is_valid(complexity: &Complexity) -> bool {
     let p = &complexity.params;
     // Missing residuals.
-    if !p.residuals.unwrap_or(std::f64::NAN).is_finite() {
+    if !p.residuals.unwrap_or(f64::NAN).is_finite() {
         return false;
     }
     // Negative gain.


### PR DESCRIPTION
## Summary
- correct exponential test to use base 1.0

## Testing
- `cargo test --quiet` *(fails: could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6874a9802334832da05ab91f62772df0