### PR TITLE
fix: fix rank panic for polynomial complexity

### DIFF
--- a/src/complexity.rs
+++ b/src/complexity.rs
@@ -140,7 +140,7 @@ fn rank(name: Name, params: Params) -> u32 {
         Name::Cubic => 3_000,
         Name::Polynomial => match params.power {
             Some(power) => std::cmp::min((1_000.0 * power) as u32, 1_000_000),
-            None => panic!("Polynomial is missing its power parameter"),
+            None => 1_000_000,
         },
         Name::Exponential => 1_000_000,
     }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -236,3 +236,11 @@ fn zero_input_failure() {
     let data: Vec<(f64, f64)> = vec![(0.0, 0.0), (0.0, 0.0), (0.0, 0.0)];
     let (_complexity, _all) = big_o::infer_complexity(data).unwrap();
 }
+
+#[test]
+fn parse_polynomial_notation() {
+    let complexity = big_o::complexity("O(n^m)").unwrap();
+    assert_eq!(complexity.name, big_o::Name::Polynomial);
+    assert_eq!(complexity.notation, "O(n^m)");
+    assert_eq!(complexity.rank, 1_000_000);
+}


### PR DESCRIPTION
## Summary
- avoid panic when creating `O(n^m)` complexity by returning a default rank
- test parsing polynomial notation explicitly

## Testing
- `cargo fmt -- --check` *(fails: `cargo-fmt` not installed)*
- `cargo clippy -- -D warnings` *(fails: could not fetch dependencies)*
- `cargo test --quiet` *(fails: could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68754e20b228832db7e039e0c84dd16d