### PR TITLE
docs: add rustdoc for error variants

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,8 +2,11 @@ use std::fmt;
 
 #[derive(Debug)]
 pub enum Error {
+    /// Returned when the underlying least-squares solver fails.
     LSTSQError(String),
+    /// Returned when a string cannot be parsed into a [`Name`](crate::name::Name).
     ParseNotationError,
+    /// Returned when not all coefficients for the approximation function are provided.
     MissingFunctionCoeffsError,
 }
 


### PR DESCRIPTION
## Summary
- document each `Error` variant with brief descriptions

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687615534054832d88847f9a22678d46