### PR TITLE
docs: document Params and Complexity fields

### DIFF
--- a/src/complexity.rs
+++ b/src/complexity.rs
@@ -4,19 +4,33 @@ use crate::name;
 use crate::name::Name;
 use crate::params::Params;
 
-/// A structure to describe asymptotic computational complexity
+/// Result of fitting an asymptotic computational complexity to a set of
+/// measurements.
+///
+/// `Complexity` instances are typically created via [`infer_complexity`] or
+/// the [`complexity`] helper and can be compared using their [`rank`] field.
+///
+/// # Example
+/// ```
+/// # use big_o::Name;
+/// let linear = big_o::complexity("O(n)").unwrap();
+/// let quadratic = big_o::complexity("O(n^2)").unwrap();
+/// assert_eq!(linear.name, Name::Linear);
+/// assert!(linear.rank < quadratic.rank);
+/// ```
 #[derive(Clone, Debug)]
 pub struct Complexity {
-    /// Human-readable name
+    /// Human-readable name of the complexity model.
     pub name: Name,
 
-    /// Big O notation
+    /// String representation in Big&nbsp;O notation.
     pub notation: &'static str,
 
-    /// Approximation function parameters
+    /// Parameters of the fitted approximation function.
     pub params: Params,
 
-    /// Relative rank to compare complexities
+    /// Relative rank used to compare complexities.
+    /// A lower value means a better asymptotic behaviour.
     pub rank: u32,
 }
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -15,10 +15,30 @@
 /// ```
 #[derive(Clone, Debug)]
 pub struct Params {
+    /// Multiplicative coefficient of the approximation function.
+    ///
+    /// Examples:
+    /// - `f(x) = gain * x + offset`
+    /// - `f(x) = gain * base.powf(x)`
     pub gain: Option<f64>,
+
+    /// Constant offset of the approximation function.
+    ///
+    /// Example: in `f(x) = gain * x + offset` this is the `offset` term.
     pub offset: Option<f64>,
+
+    /// Sum of absolute residuals between the measured data and the
+    /// approximation.
     pub residuals: Option<f64>,
+
+    /// Exponent of a polynomial function.
+    ///
+    /// Example: `f(x) = gain * x.powf(power)`
     pub power: Option<f64>,
+
+    /// Base of an exponential function.
+    ///
+    /// Example: `f(x) = gain * base.powf(x)`
     pub base: Option<f64>,
 }
 


### PR DESCRIPTION
## Summary
- expand documentation for `Params` fields
- describe `Complexity` fields and add example

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6876173fb744832d9f0a1649689eba97