### PR TITLE
feat!: accept slices in infer_complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ use assert_approx_eq::assert_approx_eq;
 // f(x) = gain * x ^ 2 + offset
 let data = vec![(1., 1.), (2., 4.), (3., 9.), (4., 16.)];
 
-let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
 
 assert_eq!(complexity.name, big_o::Name::Quadratic);
 assert_eq!(complexity.notation, "O(n^2)");

--- a/examples/stress.rs
+++ b/examples/stress.rs
@@ -59,7 +59,7 @@ fn main() {
                 .map(|i| i as f64)
                 .map(|x| (x, f(x)))
                 .collect();
-            let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+            let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
 
             let (a, b) = match name {
                 big_o::Name::Constant => (0.0, offset),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub use crate::params::Params;
 /// // f(x) = gain * x ^ 2 + offset
 /// let data = vec![(1., 1.), (2., 4.), (3., 9.), (4., 16.)];
 ///
-/// let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+/// let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
 ///
 /// assert_eq!(complexity.name, big_o::Name::Quadratic);
 /// assert_eq!(complexity.notation, "O(n^2)");
@@ -29,10 +29,10 @@ pub use crate::params::Params;
 /// assert_approx_eq!(complexity.params.offset.unwrap(), 0.0, 1e-6);
 /// assert!(complexity.rank < big_o::complexity("O(n^3)").unwrap().rank);
 /// ```
-pub fn infer_complexity(data: Vec<(f64, f64)>) -> Result<(Complexity, Vec<Complexity>), Error> {
+pub fn infer_complexity(data: &[(f64, f64)]) -> Result<(Complexity, Vec<Complexity>), Error> {
     let mut all_fitted: Vec<Complexity> = Vec::new();
     for name in name::all_names() {
-        let complexity = complexity::fit(name, data.clone())?;
+        let complexity = complexity::fit(name, data)?;
         if validate::is_valid(&complexity) {
             all_fitted.push(complexity);
         }

--- a/src/linalg.rs
+++ b/src/linalg.rs
@@ -3,7 +3,7 @@ use crate::error::Error;
 /// Fits a line `f(x) = gain * x + offset` into input `data` points.
 ///
 /// Returns linear coeffs `gain`, `offset` and `residuals`.
-pub fn fit_line(data: Vec<(f64, f64)>) -> Result<(f64, f64, f64), Error> {
+pub fn fit_line(data: &[(f64, f64)]) -> Result<(f64, f64, f64), Error> {
     use nalgebra::{Dynamic, OMatrix, OVector, U2};
 
     let (xs, ys): (Vec<f64>, Vec<f64>) = data.iter().cloned().unzip();
@@ -37,7 +37,7 @@ mod tests {
     fn test_fit_line_1() {
         let data = vec![(0., 0.), (1., 1.), (2., 2.), (3., 3.)];
 
-        let (gain, offset, residuals) = fit_line(data).unwrap();
+        let (gain, offset, residuals) = fit_line(&data).unwrap();
 
         assert_approx_eq!(gain, 1., EPSILON);
         assert_approx_eq!(offset, 0., EPSILON);
@@ -48,7 +48,7 @@ mod tests {
     fn test_fit_line_2() {
         let data = vec![(0., 7.), (1., 17.), (2., 27.), (3., 37.)];
 
-        let (gain, offset, residuals) = fit_line(data).unwrap();
+        let (gain, offset, residuals) = fit_line(&data).unwrap();
 
         assert_approx_eq!(gain, 10., EPSILON);
         assert_approx_eq!(offset, 7., EPSILON);

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -60,7 +60,7 @@ fn infer_each() {
 
     for (f, name, notation, params) in test_cases {
         let data: Vec<(f64, f64)> = (1..100).map(|i| i as f64).map(|x| (x, f(x))).collect();
-        let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+        let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
         assert_eq!(complexity.name, name);
         assert_eq!(complexity.notation, notation);
         assert_approx_eq!(
@@ -94,7 +94,7 @@ fn infer_constant() {
     let f = Box::new(|x: f64| gain * x + offset);
 
     let data: Vec<(f64, f64)> = (1..100).map(|i| i as f64).map(|x| (x, f(x))).collect();
-    let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
 
     assert_eq!(complexity.name, name);
     assert_eq!(complexity.notation, notation);
@@ -111,7 +111,7 @@ fn infer_logarithmic() {
     let f = Box::new(|x: f64| gain * x.ln() + offset);
 
     let data: Vec<(f64, f64)> = (1..100).map(|i| i as f64).map(|x| (x, f(x))).collect();
-    let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
 
     assert_eq!(complexity.name, name);
     assert_eq!(complexity.notation, notation);
@@ -128,7 +128,7 @@ fn infer_linear() {
     let f = Box::new(|x: f64| gain * x + offset);
 
     let data: Vec<(f64, f64)> = (1..100).map(|i| i as f64).map(|x| (x, f(x))).collect();
-    let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
 
     assert_eq!(complexity.name, name);
     assert_eq!(complexity.notation, notation);
@@ -145,7 +145,7 @@ fn infer_linearithmic() {
     let f = Box::new(|x: f64| gain * x * x.ln() + offset);
 
     let data: Vec<(f64, f64)> = (1..100).map(|i| i as f64).map(|x| (x, f(x))).collect();
-    let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
 
     assert_eq!(complexity.name, name);
     assert_eq!(complexity.notation, notation);
@@ -162,7 +162,7 @@ fn infer_quadratic() {
     let f = Box::new(|x: f64| gain * x.powi(2) + offset);
 
     let data: Vec<(f64, f64)> = (1..100).map(|i| i as f64).map(|x| (x, f(x))).collect();
-    let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
 
     assert_eq!(complexity.name, name);
     assert_eq!(complexity.notation, notation);
@@ -179,7 +179,7 @@ fn infer_cubic() {
     let f = Box::new(|x: f64| gain * x.powi(3) + offset);
 
     let data: Vec<(f64, f64)> = (1..100).map(|i| i as f64).map(|x| (x, f(x))).collect();
-    let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
 
     assert_eq!(complexity.name, name);
     assert_eq!(complexity.notation, notation);
@@ -196,7 +196,7 @@ fn infer_polynomial() {
     let f = Box::new(|x: f64| gain * x.powf(power));
 
     let data: Vec<(f64, f64)> = (1..100).map(|i| i as f64).map(|x| (x, f(x))).collect();
-    let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
 
     assert_eq!(complexity.name, name);
     assert_eq!(complexity.notation, notation);
@@ -214,7 +214,7 @@ fn infer_exponential() {
     let f = Box::new(|x: f64| gain * base.powf(x));
 
     let data: Vec<(f64, f64)> = (1..100).map(|i| i as f64).map(|x| (x, f(x))).collect();
-    let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
 
     assert_eq!(complexity.name, name);
     assert_eq!(complexity.notation, notation);
@@ -227,12 +227,12 @@ fn infer_exponential() {
 #[should_panic]
 fn empty_input_failure() {
     let data: Vec<(f64, f64)> = vec![];
-    let (_complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (_complexity, _all) = big_o::infer_complexity(&data).unwrap();
 }
 
 #[test]
 #[should_panic]
 fn zero_input_failure() {
     let data: Vec<(f64, f64)> = vec![(0.0, 0.0), (0.0, 0.0), (0.0, 0.0)];
-    let (_complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (_complexity, _all) = big_o::infer_complexity(&data).unwrap();
 }

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -10,7 +10,7 @@ fn infer_exponential_stress_1() {
     let f = Box::new(|x: f64| gain * base.powf(x));
 
     let data: Vec<(f64, f64)> = (1..100).map(|i| i as f64).map(|x| (x, f(x))).collect();
-    let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
 
     println!("{:?}", complexity.params);
 
@@ -28,7 +28,7 @@ fn infer_exponential_stress_2() {
     let f = Box::new(|x: f64| gain * base.powf(x));
 
     let data: Vec<(f64, f64)> = (1..100).map(|i| i as f64).map(|x| (x, f(x))).collect();
-    let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
 
     println!("{:?}", complexity.params);
 
@@ -46,7 +46,7 @@ fn infer_logarithmic_stress_1() {
     let f = Box::new(|x: f64| gain * x.ln() + offset);
 
     let data: Vec<(f64, f64)> = (1..100).map(|i| i as f64).map(|x| (x, f(x))).collect();
-    let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
 
     println!("{:?}", complexity.params);
 

--- a/tests/execution_time.rs
+++ b/tests/execution_time.rs
@@ -74,7 +74,7 @@ fn time_infer_complexity_constant() {
     let runs = 3;
     let n: Vec<u64> = vec![1, 1_000, 1_000_000, 1_000_000_000, 1_000_000_000_000];
     let data = measure_execution_time(&n, dummy_constant, runs);
-    let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
     assert_eq!(complexity.name, big_o::Name::Constant);
 }
 
@@ -83,7 +83,7 @@ fn time_infer_complexity_logarithmic() {
     let runs = 10;
     let n: Vec<u64> = vec![1, 10, 100, 1_000, 10_000, 100_000];
     let data = measure_execution_time(&n, dummy_logarithmic, runs);
-    let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
     assert_eq!(complexity.name, big_o::Name::Logarithmic);
 }
 
@@ -92,7 +92,7 @@ fn time_infer_complexity_linear() {
     let runs = 10;
     let n: Vec<u64> = vec![1, 2, 5, 10, 50, 100, 500];
     let data = measure_execution_time(&n, dummy_linear, runs);
-    let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
     assert_eq!(complexity.name, big_o::Name::Linear);
 }
 
@@ -101,7 +101,7 @@ fn time_infer_complexity_linearithmic() {
     let runs = 10;
     let n: Vec<u64> = vec![1, 2, 5, 10, 20, 50, 100];
     let data = measure_execution_time(&n, dummy_linearithmic, runs);
-    let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
     assert_eq!(complexity.name, big_o::Name::Linearithmic);
 }
 
@@ -110,7 +110,7 @@ fn time_infer_complexity_quadratic() {
     let runs = 10;
     let n: Vec<u64> = vec![1, 2, 5, 10, 20, 50];
     let data = measure_execution_time(&n, dummy_quadratic, runs);
-    let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
     assert_eq!(complexity.name, big_o::Name::Quadratic);
 }
 
@@ -119,7 +119,7 @@ fn time_infer_complexity_cubic() {
     let runs = 5;
     let n: Vec<u64> = vec![1, 2, 5, 10, 20];
     let data = measure_execution_time(&n, dummy_cubic, runs);
-    let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
     assert_eq!(complexity.name, big_o::Name::Cubic);
 }
 
@@ -128,7 +128,7 @@ fn time_infer_complexity_polynomial() {
     let runs = 1;
     let n: Vec<u64> = vec![3, 5, 7, 9, 11, 13];
     let data = measure_execution_time(&n, dummy_polynomial, runs);
-    let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
     assert_eq!(complexity.name, big_o::Name::Polynomial);
 }
 
@@ -137,6 +137,6 @@ fn time_infer_complexity_exponential() {
     let runs = 1;
     let n: Vec<u64> = vec![1, 3, 5, 7, 9, 11];
     let data = measure_execution_time(&n, dummy_exponential, runs);
-    let (complexity, _all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
     assert_eq!(complexity.name, big_o::Name::Exponential);
 }

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -51,7 +51,7 @@ fn regression_0001() {
         (48.0, 2178477.0),
         (49.0, 2223861.0),
     ];
-    let (complexity, all) = big_o::infer_complexity(data).unwrap();
+    let (complexity, all) = big_o::infer_complexity(&data).unwrap();
     assert_eq!(
         complexity.name,
         big_o::Name::Linear,


### PR DESCRIPTION
## Summary
- [BREAKING CHANGE] accept `&[(f64, f64)]` for complexity inference
- operate on slices throughout the library
- update docs, tests, and examples

## Testing
- `./run-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68761aba396c832da60b9401feac6a6f