### PR TITLE
feat(error): implement Error trait

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -19,3 +19,5 @@ impl fmt::Display for Error {
         }
     }
 }
+
+impl std::error::Error for Error {}


### PR DESCRIPTION
## Summary
- implement `std::error::Error` for `Error`

## Testing
- `cargo clippy --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6876230e2064832d8b03e758f3883a5c