### PR TITLE
feat: return NoValidComplexity when inference fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ assert_approx_eq!(complexity.params.gain.unwrap(), 1.0, 1e-6);
 assert_approx_eq!(complexity.params.offset.unwrap(), 0.0, 1e-6);
 assert!(complexity.rank < big_o::complexity("O(n^3)").unwrap().rank);
 ```
+
+`infer_complexity` returns an [`Error::NoValidComplexity`](src/error.rs) when no
+complexity model fits the provided data, such as when the input is empty or all
+values are zero.

--- a/examples/stress.rs
+++ b/examples/stress.rs
@@ -59,6 +59,8 @@ fn main() {
                 .map(|i| i as f64)
                 .map(|x| (x, f(x)))
                 .collect();
+            // `infer_complexity` may fail if the generated data is invalid
+            // and return `Error::NoValidComplexity`.
             let (complexity, _all) = big_o::infer_complexity(&data).unwrap();
 
             let (a, b) = match name {

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,8 @@ pub enum Error {
     MissingFunctionCoeffsError,
     /// Returned when a polynomial complexity lacks a power parameter.
     MissingPolynomialPower,
+    /// Returned when no complexity model fits the input data.
+    NoValidComplexity,
 }
 
 impl fmt::Display for Error {
@@ -19,6 +21,7 @@ impl fmt::Display for Error {
             Error::ParseNotationError => write!(f, "Can't convert string to Name"),
             Error::MissingFunctionCoeffsError => write!(f, "No coefficients to compute f(x)"),
             Error::MissingPolynomialPower => write!(f, "Polynomial power parameter is missing"),
+            Error::NoValidComplexity => write!(f, "No valid complexity could be inferred"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,12 +30,18 @@ pub use crate::params::Params;
 /// assert!(complexity.rank < big_o::complexity("O(n^3)").unwrap().rank);
 /// ```
 pub fn infer_complexity(data: &[(f64, f64)]) -> Result<(Complexity, Vec<Complexity>), Error> {
+    if data.is_empty() || data.iter().all(|(x, y)| *x == 0.0 && *y == 0.0) {
+        return Err(Error::NoValidComplexity);
+    }
     let mut all_fitted: Vec<Complexity> = Vec::new();
     for name in name::all_names() {
         let complexity = complexity::fit(name, data)?;
         if validate::is_valid(&complexity) {
             all_fitted.push(complexity);
         }
+    }
+    if all_fitted.is_empty() {
+        return Err(Error::NoValidComplexity);
     }
     all_fitted.sort_by(|a, b| a.params.residuals.partial_cmp(&b.params.residuals).unwrap());
     let best_complexity = all_fitted[0].clone();

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -224,15 +224,15 @@ fn infer_exponential() {
 }
 
 #[test]
-#[should_panic]
 fn empty_input_failure() {
     let data: Vec<(f64, f64)> = vec![];
-    let (_complexity, _all) = big_o::infer_complexity(&data).unwrap();
+    let err = big_o::infer_complexity(&data).unwrap_err();
+    assert!(matches!(err, big_o::Error::NoValidComplexity));
 }
 
 #[test]
-#[should_panic]
 fn zero_input_failure() {
     let data: Vec<(f64, f64)> = vec![(0.0, 0.0), (0.0, 0.0), (0.0, 0.0)];
-    let (_complexity, _all) = big_o::infer_complexity(&data).unwrap();
+    let err = big_o::infer_complexity(&data).unwrap_err();
+    assert!(matches!(err, big_o::Error::NoValidComplexity));
 }


### PR DESCRIPTION
## Summary
- add `NoValidComplexity` error variant
- use new error if no complexity can be inferred
- document the behaviour in README and examples
- expect `Error::NoValidComplexity` in API tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687628734938832dae18cdb0f822d3de