### PR TITLE
feat: add input validation for positive x

### DIFF
--- a/src/complexity.rs
+++ b/src/complexity.rs
@@ -3,6 +3,7 @@ use crate::linalg;
 use crate::name;
 use crate::name::Name;
 use crate::params::Params;
+use crate::validate;
 
 /// Result of fitting an asymptotic computational complexity to a set of
 /// measurements.
@@ -162,6 +163,7 @@ fn rank(name: Name, params: Params) -> Result<u32, Error> {
 
 /// Fits a function of given complexity into input data.
 pub fn fit(name: Name, data: &[(f64, f64)]) -> Result<Complexity, Error> {
+    validate::check_input(name, data)?;
     let linearized: Vec<(f64, f64)> = data
         .iter()
         .copied()

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,8 @@ pub enum Error {
     MissingFunctionCoeffsError,
     /// Returned when a polynomial complexity lacks a power parameter.
     MissingPolynomialPower,
+    /// Returned when input data contains invalid values.
+    InvalidInput(String),
 }
 
 impl fmt::Display for Error {
@@ -19,6 +21,7 @@ impl fmt::Display for Error {
             Error::ParseNotationError => write!(f, "Can't convert string to Name"),
             Error::MissingFunctionCoeffsError => write!(f, "No coefficients to compute f(x)"),
             Error::MissingPolynomialPower => write!(f, "Polynomial power parameter is missing"),
+            Error::InvalidInput(msg) => write!(f, "Invalid input: {msg}"),
         }
     }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,6 +1,7 @@
 use crate::complexity::Complexity;
 use crate::name::Name;
 use crate::params::Params;
+use crate::Error;
 use float_cmp::approx_eq;
 
 const EPSILON: f64 = 1e-5;
@@ -62,6 +63,20 @@ pub fn is_valid(complexity: &Complexity) -> bool {
     }
 
     true
+}
+
+/// Validates input data for a given complexity model.
+pub fn check_input(name: Name, data: &[(f64, f64)]) -> Result<(), Error> {
+    let requires_positive = matches!(
+        name,
+        Name::Logarithmic | Name::Linearithmic | Name::Polynomial
+    );
+    if requires_positive {
+        if data.iter().any(|(x, _)| *x <= 0.0) {
+            return Err(Error::InvalidInput("x values must be positive".to_string()));
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -231,8 +231,15 @@ fn empty_input_failure() {
 }
 
 #[test]
-#[should_panic]
-fn zero_input_failure() {
+fn zero_input_error() {
     let data: Vec<(f64, f64)> = vec![(0.0, 0.0), (0.0, 0.0), (0.0, 0.0)];
-    let (_complexity, _all) = big_o::infer_complexity(&data).unwrap();
+    let err = big_o::infer_complexity(&data).unwrap_err();
+    assert!(matches!(err, big_o::Error::InvalidInput(_)));
+}
+
+#[test]
+fn negative_input_error() {
+    let data: Vec<(f64, f64)> = vec![(-1.0, 1.0), (-2.0, 4.0)];
+    let err = big_o::infer_complexity(&data).unwrap_err();
+    assert!(matches!(err, big_o::Error::InvalidInput(_)));
 }


### PR DESCRIPTION
## Summary
- check inputs for positive X when needed
- return InvalidInput errors on bad data
- test zero and negative values

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68762874c610832dbed7bc3af64c933d