### PR TITLE
feat: accept_range for short ladders, optional serde support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ Breaking: every public type changed. See the README for the current shape.
 - `is_at_most` and `is_faster_than` compare a fit against a named bound.
 - `Analysis` restricts inference to a chosen set of models.
 - `Display for Fit` substitutes fitted values: `O(n^1.5)`, `O(2^n)`.
+- `Analysis::accept_range` declares the ladder a caller can afford, so the
+  range warnings fire only below it — an acknowledged short ladder stops
+  repeating itself, and the warnings that matter stay loud.
+- A `serde` feature (off by default) derives `Serialize`/`Deserialize` for the
+  result types, so a verdict can be persisted and compared against a later run.
 - Repeated measurements of one input size are collapsed to their median, so a
   descheduled run does not steer the result.
 - `rust-version` is declared and built in CI.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,16 @@ categories = ["development-tools", "development-tools::profiling", "development-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# Optional: `Serialize`/`Deserialize` on the result types, for persisting an
+# inference and comparing verdicts across runs (CI baselines and the like).
+serde = { version = "1", features = ["derive"], optional = true }
+
+[features]
+serde = ["dep:serde"]
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
 proptest = "1"
+# float_roundtrip: a stored verdict must parse back to the exact written
+# value, or a baseline comparison drifts by an ulp per round trip.
+serde_json = { version = "1", features = ["float_roundtrip"] }

--- a/README.md
+++ b/README.md
@@ -89,6 +89,46 @@ let inference = Analysis::new()
 assert_eq!(inference.best.model, Model::Quadratic);
 ```
 
+## Accepting a short ladder
+
+The range warnings advise the sample that makes every model separable. A real
+benchmark often cannot afford it — the widest rungs are the expensive ones —
+and a warning that fires on every run of an accepted trade-off stops being
+read. Declare the ladder you can afford, and the warnings fire only below it:
+
+```rust
+use big_o::Analysis;
+
+let measurements = [(100., 105.), (200., 198.), (400., 405.), (1000., 1002.)];
+
+let inference = Analysis::new()
+    .accept_range(4, 1.0) // four sizes over one decade, knowingly
+    .infer(&measurements)
+    .unwrap();
+
+assert!(inference.warnings.is_empty());
+```
+
+This changes which warnings are raised and nothing else — the inference is
+exactly as weak as it was; you have signed off on that weakness, not repaired
+it.
+
+## Serialization
+
+The `serde` feature (off by default) derives `Serialize`/`Deserialize` for the
+result types, so an inference can be written down and compared against a later
+run — a committed baseline in CI, a saved report:
+
+```toml
+big_o = { version = "0.2", features = ["serde"] }
+```
+
+Inference is deterministic — the same measurements always produce the same
+result, including `confidence` — which is what makes a stored verdict worth
+comparing against at all. If you store as JSON and compare bit-exactly, enable
+`serde_json`'s `float_roundtrip` feature: its default float parsing can be an
+ulp off, which is drift a comparison would report as a change.
+
 ## Errors
 
 - `NotEnoughData` — fewer than three distinct input sizes. Repeated measurements

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -65,6 +65,7 @@ const SEED: u64 = 0x9E37_79B9_7F4A_7C15;
 
 /// The outcome of inferring a complexity from measurements.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Inference {
     /// The model that best describes the measurements.
     pub best: Fit,
@@ -103,6 +104,8 @@ pub struct Inference {
 #[derive(Clone, Debug)]
 pub struct Analysis {
     models: Vec<Model>,
+    advised_points: usize,
+    advised_decades: f64,
 }
 
 impl Default for Analysis {
@@ -116,6 +119,8 @@ impl Analysis {
     pub fn new() -> Self {
         Self {
             models: model::ALL.to_vec(),
+            advised_points: ADVISED_POINTS,
+            advised_decades: ADVISED_DECADES,
         }
     }
 
@@ -126,6 +131,37 @@ impl Analysis {
     /// the best of the models they consider possible rather than of all of them.
     pub fn models(mut self, models: impl IntoIterator<Item = Model>) -> Self {
         self.models = models.into_iter().collect();
+        self
+    }
+
+    /// Declares the ladder the caller can afford, so [`Warning::TooFewPoints`]
+    /// and [`Warning::NarrowRange`] are raised only below it.
+    ///
+    /// The default thresholds describe the sample that makes every model
+    /// separable. Real benchmarks often cannot afford that sample — the widest
+    /// rungs are the expensive ones — and a warning that fires on every run of
+    /// an accepted trade-off stops being read, taking the warnings that matter
+    /// down with it. Declaring the trade-off keeps the remaining warnings loud.
+    ///
+    /// This changes which warnings are raised and nothing else: not the fit,
+    /// not the confidence, and not how separable the models actually are on a
+    /// short ladder. The inference is exactly as weak as it was — the caller
+    /// has signed off on that weakness, not repaired it.
+    ///
+    /// # Example
+    /// ```
+    /// use big_o::Analysis;
+    ///
+    /// let data = [(100., 105.), (200., 198.), (400., 405.), (1000., 1002.)];
+    ///
+    /// // Four sizes over one decade, accepted as such: no range warnings.
+    /// let inference = Analysis::new().accept_range(4, 1.0).infer(&data).unwrap();
+    ///
+    /// assert!(inference.warnings.is_empty());
+    /// ```
+    pub fn accept_range(mut self, sizes: usize, decades: f64) -> Self {
+        self.advised_points = sizes;
+        self.advised_decades = decades;
         self
     }
 
@@ -222,18 +258,18 @@ impl Analysis {
         let mut warnings = Vec::new();
 
         let points = sample.points().len();
-        if points < ADVISED_POINTS {
+        if points < self.advised_points {
             warnings.push(Warning::TooFewPoints {
                 got: points,
-                advised: ADVISED_POINTS,
+                advised: self.advised_points,
             });
         }
 
         let decades = sample.decades();
-        if decades < ADVISED_DECADES {
+        if decades < self.advised_decades {
             warnings.push(Warning::NarrowRange {
                 decades,
-                advised: ADVISED_DECADES,
+                advised: self.advised_decades,
             });
         }
 

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -12,6 +12,7 @@ use std::fmt;
 /// polynomial always has an exponent and a fitted line never carries an unused
 /// one. There is no representable fit with a parameter missing.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ModelParams {
     /// `f(x) = offset`
     Constant {
@@ -111,6 +112,7 @@ impl ModelParams {
 /// assert!(inference.best.is_at_most(big_o::Model::Cubic));
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Fit {
     /// The model class that was fitted.
     pub model: Model,

--- a/src/model.rs
+++ b/src/model.rs
@@ -9,6 +9,7 @@ use std::str::FromStr;
 /// model has been fitted to data. See [`Fit`](crate::Fit) for the result of
 /// that fitting.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Model {
     /// `O(1)`
     Constant,

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -8,6 +8,7 @@ use std::fmt;
 /// under which that choice was made, so a result that happens to be right for
 /// the wrong reasons can be told apart from one that is supported by the data.
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Warning {
     /// The sample has few distinct input sizes. The fit is determined, but
     /// there is little room for the models to disagree, so the winner is

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,40 @@
+//! The `serde` feature: an inference survives a serialization round trip.
+//!
+//! The use case is persistence — write a verdict down, read it back later,
+//! compare it against a fresh run (a committed CI baseline, a saved report).
+//! So the test asserts the round trip preserves the fields such a comparison
+//! reads, not any particular wire format.
+
+#![cfg(feature = "serde")]
+
+fn quadratic() -> big_o::Inference {
+    let data = [
+        (100., 10_180.),
+        (200., 39_800.),
+        (400., 161_440.),
+        (800., 637_440.),
+        (1600., 2_570_240.),
+        (3200., 10_352_640.),
+    ];
+    big_o::infer_complexity(&data).expect("quadratic data infers")
+}
+
+#[test]
+fn inference_round_trips() {
+    let before = quadratic();
+    let json = serde_json::to_string(&before).expect("inference serializes");
+    let after: big_o::Inference = serde_json::from_str(&json).expect("inference deserializes");
+
+    assert_eq!(after.best, before.best);
+    assert_eq!(after.all, before.all);
+    assert_eq!(after.warnings, before.warnings);
+    assert!((after.confidence - before.confidence).abs() < f64::EPSILON);
+}
+
+#[test]
+fn model_name_is_stable_in_json() {
+    let json = serde_json::to_string(&big_o::Model::Linearithmic).expect("model serializes");
+    // The variant name is the wire format; a rename would break stored
+    // baselines, so it is pinned here.
+    assert_eq!(json, "\"Linearithmic\"");
+}


### PR DESCRIPTION
Two additions for using the crate against real benchmark ladders, before the 0.2.0 release.

**`Analysis::accept_range(sizes, decades)`.**
The range warnings advise the sample that separates every model, but real benchmarks often cannot afford it — the widest rungs are the expensive ones — and a warning that fires on every run of an accepted trade-off stops being read, taking the warnings that matter down with it.
Declaring the ladder keeps the remaining warnings loud.
It changes which warnings are raised and nothing else: the fit, the confidence, and the actual separability of a short ladder are untouched — the caller signs off on the weakness, not repairs it.

**`serde` feature (off by default).**
`Serialize`/`Deserialize` on the result types, so a verdict can be persisted and compared against a later run — the committed-baseline pattern criterion and similar tools use in CI.
Deterministic inference (fixed resampling seed) is what makes a stored verdict comparable at all; the round-trip test also pins the `Model` variant names as the wire format, since a rename would break stored baselines.
The README notes `serde_json`'s `float_roundtrip` caveat: its default float parsing is up to an ulp off, which a bit-exact comparison would report as drift.

No default-feature or API breakage; CI already runs `--all-features`, so both are exercised with no workflow change.
