### PR TITLE
refactor!: trim public API and package contents before first publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,16 @@ Breaking: every public type changed. See the README for the current shape.
   missing parameter cannot be constructed.
 - The numeric rank is no longer public.
 - Errors are named consistently; `NotEnoughData` reports what it needed.
+- `Error`, `Warning`, `Fit` and `Inference` are `#[non_exhaustive]`: a new
+  failure, a new way for measurements to mislead, or a new score is additive
+  rather than breaking. `Model` and `ModelParams` deliberately are not — they
+  name the complexity classes the crate knows, and a caller matching on the
+  answer should be told by the compiler when that vocabulary grows.
 
 ### Removed
 
 - All runtime dependencies — `nalgebra`, `lstsq` and `float-cmp`.
 - Sleep-based tests, which spent about ten seconds of every CI run asleep.
+- `TryFrom<&str> for Model` and `From<Model> for &str`. `"O(n^2)".parse()` and
+  `Model::notation()` already did both jobs, and two spellings of one operation
+  is a decision handed to the reader for nothing.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,17 @@ license = "Apache-2.0"
 keywords = ["big_o", "complexity", "analysis", "performance", "algorithm"]
 categories = ["development-tools", "development-tools::profiling", "development-tools::testing"]
 
+# What a consumer of the published crate can use: the library, the tests that
+# hold it to its claims, and the prose. CI config, helper scripts and the
+# toolchain pin serve this repository, not anyone depending on it.
+include = ["/src", "/tests", "/README.md", "/CHANGELOG.md", "/LICENSE"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+# The serde impls are behind a feature, and a feature docs.rs does not turn on
+# is a feature nobody can see documented.
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 # Optional: `Serialize`/`Deserialize` on the result types, for persisting an

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -64,8 +64,11 @@ const RESAMPLES: usize = 100;
 const SEED: u64 = 0x9E37_79B9_7F4A_7C15;
 
 /// The outcome of inferring a complexity from measurements.
+///
+/// Non-exhaustive: read the fields, but let the crate build the value.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub struct Inference {
     /// The model that best describes the measurements.
     pub best: Fit,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,11 @@
 use std::fmt;
 
 /// Reasons a complexity could not be produced.
+///
+/// Non-exhaustive: match with a `_` arm, because a later release may fail for a
+/// reason this one has no name for.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Error {
     /// Returned when the sample holds too few distinct input sizes to tell the
     /// models apart. Repeated measurements of one input size collapse to a

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -111,8 +111,12 @@ impl ModelParams {
 /// assert_eq!(inference.best.model, big_o::Model::Quadratic);
 /// assert!(inference.best.is_at_most(big_o::Model::Cubic));
 /// ```
+///
+/// Non-exhaustive: read the fields, but let the crate build the value. A later
+/// release may score a fit on something this one does not measure.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub struct Fit {
     /// The model class that was fitted.
     pub model: Model,

--- a/src/model.rs
+++ b/src/model.rs
@@ -52,7 +52,10 @@ const LOG_DEGREE: f64 = 0.13;
 impl Model {
     /// The notation this model is written in, with any fitted parameter left
     /// symbolic. [`Fit`](crate::Fit)'s `Display` substitutes the fitted value.
-    pub fn notation(&self) -> &'static str {
+    ///
+    /// This is what `Display` writes; it is a separate method because the
+    /// notation is a `&'static str` and `Display` cannot hand one back.
+    pub fn notation(self) -> &'static str {
         match self {
             Model::Constant => "O(1)",
             Model::Logarithmic => "O(log n)",
@@ -110,17 +113,13 @@ impl Model {
     }
 }
 
-impl From<Model> for &str {
-    fn from(model: Model) -> &'static str {
-        model.notation()
-    }
-}
+/// Parses either the notation or the name of a model, in any case:
+/// `"O(n log n)"` and `"linearithmic"` are the same model.
+impl FromStr for Model {
+    type Err = Error;
 
-impl TryFrom<&str> for Model {
-    type Error = Error;
-
-    fn try_from(string: &str) -> Result<Self, Self::Error> {
-        match &string.to_lowercase()[..] {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match &s.to_lowercase()[..] {
             "o(1)" | "constant" => Ok(Model::Constant),
             "o(log n)" | "logarithmic" => Ok(Model::Logarithmic),
             "o(n)" | "linear" => Ok(Model::Linear),
@@ -131,14 +130,6 @@ impl TryFrom<&str> for Model {
             "o(c^n)" | "exponential" => Ok(Model::Exponential),
             _ => Err(Error::ParseNotation),
         }
-    }
-}
-
-impl FromStr for Model {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        s.try_into()
     }
 }
 
@@ -175,36 +166,29 @@ mod tests {
     ];
 
     #[test]
-    fn model_into_string() {
+    fn writes_its_notation() {
         for (string, model) in NOTATION_TEST_CASES {
-            let converted: &str = model.into();
-            assert_eq!(converted, string);
-        }
-    }
-
-    #[test]
-    fn model_to_string() {
-        for (string, model) in NOTATION_TEST_CASES {
-            assert_eq!(model.to_string(), string);
+            assert_eq!(model.notation(), string);
+            assert_eq!(model.to_string(), string, "Display must agree");
         }
     }
 
     #[test]
     fn parses_notation_and_name() {
         for (string, model) in [NOTATION_TEST_CASES, NAMED_TEST_CASES].concat() {
-            assert_eq!(Model::try_from(string), Ok(model));
             assert_eq!(string.parse::<Model>(), Ok(model));
-            let into: Model = string.try_into().expect("a known notation");
-            assert_eq!(into, model);
+        }
+    }
+
+    #[test]
+    fn parses_back_what_it_writes() {
+        for model in ALL {
+            assert_eq!(model.notation().parse::<Model>(), Ok(model));
         }
     }
 
     #[test]
     fn rejects_unknown_notation() {
-        assert_eq!(
-            Model::try_from("irrelevant text"),
-            Err(Error::ParseNotation)
-        );
         assert_eq!(
             "irrelevant text".parse::<Model>(),
             Err(Error::ParseNotation)

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -7,8 +7,13 @@ use std::fmt;
 /// A warning never changes which model was chosen. It reports the conditions
 /// under which that choice was made, so a result that happens to be right for
 /// the wrong reasons can be told apart from one that is supported by the data.
+///
+/// Non-exhaustive: match with a `_` arm, or just `Display` it. Learning to spot
+/// a new way for measurements to mislead is the point of the type, and adding
+/// one should not break the callers who already print whatever it finds.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub enum Warning {
     /// The sample has few distinct input sizes. The fit is determined, but
     /// there is little room for the models to disagree, so the winner is


### PR DESCRIPTION
Trims the v0.2 surface to what earns its keep, and makes the crate package cleanly, before the first publish freezes both.

Every `pub` item becomes a semver promise the moment this goes to crates.io, so the cheap moment to say less is now.

**Removed** `TryFrom<&str> for Model` and `From<Model> for &str`.
`"O(n^2)".parse()` and `Model::notation()` already did both jobs; two spellings of one operation is a decision handed to the reader for nothing.

**Marked `Error`, `Warning`, `Fit` and `Inference` `#[non_exhaustive]`.**
A new failure mode, a new way for measurements to mislead, or a new score on a fit is then additive rather than breaking.
`Model` and `ModelParams` are deliberately left exhaustive: they name the complexity classes the crate knows, and a caller matching on the answer *should* be told by the compiler when that vocabulary grows.

**Packaging.**
The published crate shipped `run-all.sh`, `scripts/`, `.github/` and the toolchain pin — repository furniture, not anything a dependant can use.
`include` now ships the library, the tests that hold it to its claims, and the prose.
`docs.rs` builds with `all-features`, without which the `serde` impls are documented nowhere anyone can see them.

Two things considered and rejected: `Ord` on `Model` (the derived order would claim `Cubic < Polynomial`, which is false for a fitted `n^0.5`), and folding `ModelParams::evaluate` into `Fit::evaluate` (params outlive a fit through serde, and evaluating them is the reason to keep them).

No behaviour changes — the same measurements infer the same complexity.
