### PR TITLE
ci: check semver, default features, and stop steps hiding each other

### DIFF
--- a/.github/workflows/pre-merge-checks.yaml
+++ b/.github/workflows/pre-merge-checks.yaml
@@ -31,9 +31,20 @@ env:
   TERM: xterm-256color
 
 jobs:
-  # One job, one build. Splitting format, lint and test across jobs meant
-  # compiling the crate three times over to run three commands against the
-  # same code, and gating all three behind a fourth build that only built it.
+  # One job, because splitting these across jobs buys nothing here and costs a
+  # runner start and a cache restore each time — `Swatinem/rust-cache` keys on
+  # the job, so three jobs warm three caches. A separate `build` job would be
+  # pure duplication besides: `cargo test` builds everything it runs.
+  #
+  # Not, however, because the steps share a build. Clippy runs under a rustc
+  # wrapper of its own, so its artifacts carry a different fingerprint and
+  # `cargo test` rebuilds regardless: measured cold, clippy takes 3.4s and the
+  # test build that follows it 4.0s against 4.4s on its own. Sharing a job saves
+  # under half a second, and the reason to keep it is the runner, not the build.
+  #
+  # Every step below therefore runs even after one has failed. Nothing is gained
+  # by hiding a test failure behind a misplaced space, and a second round trip
+  # to discover it is exactly what a fast CI run is for avoiding.
   check:
     name: fmt + clippy + test
     runs-on: ubuntu-latest
@@ -47,16 +58,28 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Check action pins
+        if: ${{ !cancelled() }}
         run: ./scripts/check-action-pins.sh
 
       - name: Format
+        if: ${{ !cancelled() }}
         run: cargo fmt --all -- --check
 
       - name: Clippy
+        if: ${{ !cancelled() }}
         run: cargo clippy --all-targets --all-features -- -D clippy::all
+
+      # Everything else here passes `--all-features`, which never compiles the
+      # crate as most of its dependants take it: `serde` is optional and off by
+      # default. A serde-only import that escaped its `#[cfg]` would merge green
+      # and break every default-feature build. This is the step that notices.
+      - name: Check without optional features
+        if: ${{ !cancelled() }}
+        run: cargo check --all-targets
 
       # Includes the bounded accuracy sweep. The wider one is scheduled.
       - name: Test
+        if: ${{ !cancelled() }}
         run: cargo test --all-features
 
   # Its own job despite the one-build rule above: this builds the *published*

--- a/.github/workflows/pre-merge-checks.yaml
+++ b/.github/workflows/pre-merge-checks.yaml
@@ -58,3 +58,28 @@ jobs:
       # Includes the bounded accuracy sweep. The wider one is scheduled.
       - name: Test
         run: cargo test --all-features
+
+  # Its own job despite the one-build rule above: this builds the *published*
+  # version as well as this one, and does it with a rustdoc that emits JSON,
+  # so it shares no compilation with `check` and would only make that job wait.
+  semver:
+    name: semver
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Compares the public API against the latest release on crates.io and
+      # fails when a change needs a version bump the manifest has not made.
+      #
+      # Under 0.x that means the minor: 0.2.0 -> 0.3.0 is the breaking bump, so
+      # a PR that removes or reshapes public API carries the bump with it rather
+      # than leaving it to be remembered at release time. Which is the point —
+      # `#[non_exhaustive]` and the rest of the 0.2 surface were chosen to make
+      # additions cheap, and nothing checks that intent held except this.
+      #
+      # `--all-features` because the serde impls are public API too, and API
+      # behind a feature flag is API nobody checks by default.
+      - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
+        with:
+          feature-group: all-features


### PR DESCRIPTION
Three changes to the pull-request checks, now that 0.2.0 is published and a merge can break someone's build.

**A `cargo-semver-checks` job**, comparing the public API against the latest release on crates.io.
The 0.2 surface was shaped around staying compatible — `#[non_exhaustive]` on the types expected to grow, the duplicate string conversions removed while removal was still free — and nothing verified that the intent held. A rule is only read by whoever already remembered it, which is why `check-action-pins.sh` exists too.

It fails when a change needs a version bump the manifest has not made; under 0.x that is the minor, so a PR that reshapes public API carries `0.2.0 -> 0.3.0` with it rather than leaving the bump to be remembered at release time.
Verified by demoting `Fit::is_faster_than` to private on this branch: the job failed in 16s with `inherent_method_missing`, naming the method and the baseline it came from. That commit was force-pushed away.

**A check without optional features.**
Every other invocation in both workflows passes `--all-features`, so nothing anywhere compiled the crate the way most dependants take it — `serde` is optional and off by default. A serde-only import that escaped its `#[cfg]` would have merged green and broken every default-feature build.

**Steps no longer hide each other.**
`cargo fmt --check` failing meant clippy and the tests never ran, so a stray space cost a full round trip before you learned the tests were broken too. Each step now runs regardless and reports on its own.

The job comment claimed splitting these apart would mean "compiling the crate three times over". That is not what happens: clippy runs under a rustc wrapper of its own, so `cargo test` rebuilds after it anyway — measured cold, clippy 3.4s and the test build after it 4.0s, against 4.4s alone. Sharing a job saves under half a second. The real reason to keep one job is the runner start and the per-job cache, so the comment now says that instead.
